### PR TITLE
feat: adds scriptSrc config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ export const usePanelbear = (site, config = {}) => {
 
   useEffect(() => {
     Panelbear.load(site, config);
-    
+
     // Trigger initial page view
     Panelbear.trackPageview();
 
@@ -91,6 +91,9 @@ export const usePanelbear = (site, config = {}) => {
 
 
 ## Changelog
+### 1.2.0
+- Allow scriptSrc config option to load Panelbear script from own domain.
+
 ### 1.1.0
 - By default, load tracker with `autoTrack` set to `false`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export interface PanelbearConfig {
   site?: string;
   debug?: boolean;
   analyticsHost?: string;
+  scriptSrc?: string;
   honorDNT?: boolean;
   autoTrack?: boolean;
   spaMode?: 'history' | 'off';
@@ -36,7 +37,9 @@ const interpret: PanelbearInterpreter = (command: any, arg1?: any): void => {
 export const load = (site: string, config?: PanelbearConfig): void => {
   const tracker = document.createElement('script');
   tracker.async = true;
-  tracker.src = `${SCRIPT_CDN_HOST}/analytics.js?site=${site}`;
+  tracker.src = config?.scriptSrc
+    ? `${config.scriptSrc}?site=${site}`
+    : `${SCRIPT_CDN_HOST}/analytics.js?site=${site}`;
   document.head.appendChild(tracker);
 
   interpret('config', {


### PR DESCRIPTION
This PR adds a new config option to the client allowing it to load the `<script ...` tag from a user's own domain. Using this option in conjunction with `analyticsHost` allows me to load the js file and fire track calls through my own domain. In next.js this can be done with 

```js
// next.config.js

module.exports = {
  async rewrites() {
    return [
      {
        source: "/bear.js",
        destination: "https://cdn.panelbear.com/analytics.js",
      },
      {
        source: "/_panelbear/:slug*",
        destination: "https://api.panelbear.com/:slug*",
      },
    ];
  },
};

// ./hooks/usePanelbear.js

Panelbear.load(site,{scriptSrc: '/bear.js', analyticsHost: '/_panelbear'});
```
